### PR TITLE
fix: label desc

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -59,5 +59,5 @@
   description: "Used for referencing DevContainers"
   color: 006b75
 - name: "docker"
-  description: "Used for referencing Docker"
+  description: "Used for referencing Docker related issues"
   color: 006b75


### PR DESCRIPTION
This pull request includes a small update to the `.github/labels.yml` file. The change refines the description of the "docker" label to specify that it is used for referencing Docker-related issues.