### PR TITLE
[Repo] Add AI and repo CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 
 # GitHub Actions workflows
 .github/workflows/* @mrz1836
+.github/.env.shared @mrz1836
 
 # Documentation files
 *.md @mrz1836
@@ -19,3 +20,13 @@ Makefile @mrz1836
 # Go module dependencies
 go.mod @mrz1836
 go.sum @mrz1836
+
+# AI Config Files
+.github/AGENTS.md @mrz1836
+.cursorrules @mrz1836
+.github/CLAUDE.md @mrz1836
+sweep.yml @mrz1836
+
+# Repository configuration
+.github/labels.yml @mrz1836
+.github/dependabot.yml @mrz1836


### PR DESCRIPTION
## What Changed
- added `.github/.env.shared` entry under GitHub Actions workflows in CODEOWNERS
- created **AI Config Files** and **Repository configuration** sections
- assigned owners for new config files to `@mrz1836`

## Why It Was Necessary
- keep ownership up to date for AI-related and repository configuration files

## Testing Performed
- `make lint`
- `make test`

## Impact / Risk
- minimal; only updates CODEOWNERS metadata

_Assigned: @mrz1836_

------
https://chatgpt.com/codex/tasks/task_e_6878ee937c5c8321a7105d07d68c1894